### PR TITLE
Fix for background task termination leading to broken functionality

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,7 +1,5 @@
 // background.ts
 
-type HeaderOperation = "append" | "set" | "remove" | "removeIfEmpty";
-
 const ROUTING_KEY = "routingKey";
 const ENABLED_KEY = "enabled";
 const ROUTING_HEADER_KEYS: string[] = [
@@ -161,3 +159,4 @@ chrome.storage.onChanged.addListener((changes, areaName) => {
 });
 
 debug("outside");
+updateInMemoryValues();


### PR DESCRIPTION
Before:
- Apparently, the termination of background task by Chrome (unpredictable GC) was leading to the local values for the background (background.js) to be cleared, defaulting `enabled` to false.

Fix:
- Calling the function to reinstate the values for the local variables for `enabled` and `routingKey` from Chrome local storage at the top level (outside of hooks). With this, any action that leads to reinstatement of the background process (eg. selection of a different sandbox) would reinstate the values from Local Storage, leading to a smooth operation.