### PR TITLE
Update exclusions of header injection

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -57,7 +57,7 @@ const getRules = (
               },
               condition: {
                 urlFilter: "*",
-                excludedRequestDomains: ["preview.signadot.com"],
+                excludedRequestDomains: ["preview.signadot.com", "preview.staging.signadot.com", "localhost.signadot.com"],
                 resourceTypes: MODIFY_HEADER_IN_RESOURCE_TYPES,
               },
             } as chrome.declarativeNetRequest.Rule)


### PR DESCRIPTION
We don't want to inject headers when other components will be injecting headers already like the preview server.