### PR TITLE
[potential fix] no-cache header for calls to Signadot API endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Signadot",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Signadot",
   "main": "index.js",
   "scripts": {
@@ -19,6 +19,7 @@
   "dependencies": {
     "@blueprintjs/core": "5.7.1",
     "@blueprintjs/select": "5.0.19",
+    "axios": "^1.7.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.12.0",

--- a/src/axiosSetup.ts
+++ b/src/axiosSetup.ts
@@ -1,0 +1,15 @@
+// axiosSetup.ts
+
+import axios from 'axios';
+
+// Setting as a constant for now. Move it to an environment file later
+export const SIGNADOT_API_DOMAIN = "https://api.signadot.com";
+
+// Set default base URL
+axios.defaults.baseURL = SIGNADOT_API_DOMAIN;
+
+// Set default headers
+axios.defaults.headers.common['Content-Type'] = 'application/json';
+axios.defaults.headers.common['Cache-Control'] = 'no-cache';
+
+// You can also set other defaults here as needed

--- a/src/components/ListRouteEntries/queries.ts
+++ b/src/components/ListRouteEntries/queries.ts
@@ -1,8 +1,9 @@
 import {RoutingEntity} from "./types";
 import {auth} from "../../contexts/auth";
+import axios from "axios";
 
 export const useFetchSandboxes = async (
-    orgName?: string
+  orgName?: string
 ): Promise<RoutingEntity[]> => {
   // Wrap the auth and fetch logic inside a new Promise
   return new Promise((resolve, reject) => {
@@ -12,21 +13,15 @@ export const useFetchSandboxes = async (
         return;
       }
 
-      fetch(`https://api.signadot.com/api/v2/orgs/${orgName}/sandboxes`)
-          .then((response) => {
-            if (!response.ok) {
-              throw new Error("Failed to fetch sandboxes");
-            }
-            return response.json();
-          })
-          .then((data) => resolve(data))
-          .catch((error) => reject(error));
+      axios.get<RoutingEntity[]>(`/api/v2/orgs/${orgName}/sandboxes`)
+        .then((response) => resolve(response.data))
+        .catch((error) => reject(error));
     });
   });
 };
 
 export const useFetchRouteGroups = async (
-    orgName?: string
+  orgName?: string
 ): Promise<RoutingEntity[]> => {
   // Wrap the auth and fetch logic inside a new Promise
   return new Promise((resolve, reject) => {
@@ -36,15 +31,9 @@ export const useFetchRouteGroups = async (
         return;
       }
 
-      fetch(`https://api.signadot.com/api/v2/orgs/${orgName}/routegroups`)
-          .then((response) => {
-            if (!response.ok) {
-              throw new Error("Failed to fetch route groups");
-            }
-            return response.json();
-          })
-          .then((data) => resolve(data))
-          .catch((error) => reject(error));
+      axios.get<RoutingEntity[]>(`/api/v2/orgs/${orgName}/routegroups`)
+        .then((response) => resolve(response.data))
+        .catch((error) => reject(error));
     });
   });
 };

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 import React, {createContext, useContext, useState} from "react";
 import {auth} from "./auth";
 import Layout from "../components/Layout/Layout";
+import axios from "axios";
 
 const loadingIconPath = chrome.runtime.getURL("images/loading.gif");
 
@@ -51,9 +52,9 @@ export const AuthProvider: React.FC<Props> = ({children}) => {
   React.useEffect(() => {
     auth((authenticated) => {
       if (authenticated) {
-        fetch("https://api.signadot.com/api/v1/orgs")
-            .then((response) => response.json())
-            .then((data: GetOrgsResponse) => {
+        axios.get<GetOrgsResponse>("/api/v1/orgs")
+            .then((response) => {
+              const data = response.data;
               setAuthState({
                 org: data.orgs[0], // TODO: Ensure safe access
                 user: {

--- a/src/contexts/auth.ts
+++ b/src/contexts/auth.ts
@@ -1,14 +1,16 @@
+import {SIGNADOT_API_DOMAIN} from "../axiosSetup";
+
 type PostAuthCallbackFn = (authenticated: boolean) => void;
 const AUTH_SESSION_COOKIE_NAME = "signadot-auth";
 const DUMMY_PREVIEW_ENDPOINT =
     "https://dummy-preview-endpoint.preview.signadot.com";
-const SIGNADOT_API_DOMAIN = "https://api.signadot.com";
 
 const refreshPreviewDomainCookies = () => {
   // Synchronous fetch request to https://xyz.preview.signadot.com
   try {
     let xhr = new XMLHttpRequest();
     xhr.open("GET", DUMMY_PREVIEW_ENDPOINT, false); // false for synchronous request
+    xhr.setRequestHeader("Cache-Control", "no-cache");
     xhr.send();
   } catch (error) {
     // empty response expected. ignore

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -4,6 +4,7 @@ import Frame from "./components/Frame";
 import "@blueprintjs/core/lib/css/blueprint.css";
 import {AuthProvider} from "./contexts/AuthContext";
 import {QueryClient, QueryClientProvider} from "react-query";
+import "./axiosSetup"; // For the extension to pick up axios setup (baseURL, headers etc)
 
 const queryClient = new QueryClient();
 const root = createRoot(document.getElementById("root")!);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1041,6 +1041,20 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+axios@^1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.3.tgz#a1125f2faf702bc8e8f2104ec3a76fab40257d85"
+  integrity sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.7.0.tgz#f4369919225b684c56085998ac63dbd05be020d5"
@@ -1328,6 +1342,13 @@ colorette@^2.0.14:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -1436,6 +1457,11 @@ deepmerge@^4.2.2:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -1676,6 +1702,20 @@ flat@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
+
+follow-redirects@^1.15.6:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2502,7 +2542,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.27:
+mime-types@^2.1.12, mime-types@^2.1.27:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -2799,6 +2839,11 @@ prop-types@^15.6.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 prr@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This is to potentially fix the issue https://github.com/signadot/community/issues/55, but it's difficult to be sure without a proper repro. More detail below.

The logged in state in the extension is governed by the presence of the cookie `signadot-auth` which is set to the `api` domain from the response of the call to the `preview` domain. If the user was in-fact authenticated in the application (which sets the cookie in the preview domain), the extension should have been able to get the cookie and mark the user as authenticated. This leads to two possible causes:

1. The preview domain didn't have the cookie set (issue is external to the extension)
2. The extension wasn't able to get the cookie

It'll require a repro to confirm case #1. In the absence of repro steps, I'm trying to fix for a possible case of (browser) caching that could lead to the extension not getting the latest cookies from the api domain.

Changes:
- I have configured XMLHttpRequest call for `no-cache`
- I have switched the implementation for other endpoint calls (get org info, sandboxes, routegroups) from `fetch` to `axios` and configured it for no-cache calls so that those get uncached response as well.