### PR TITLE
fix template value for custom headers

### DIFF
--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -51,7 +51,7 @@ export const getHeaders = (extraHeaders: string[] | undefined): Record<string, H
       .filter(([_, header]) => header.kind === "always")
       .reduce((acc, [key, header]) => ({ ...acc, [key]: header }), {});
 
-  const extraHeadersObj = extraHeaders.reduce((acc, header) => ({ ...acc, [header]: { value: header, kind: "extra" } }), {});
+  const extraHeadersObj = extraHeaders.reduce((acc, header) => ({ ...acc, [header]: { value: `${ROUTING_KEY_PLACEHOLDER}`, kind: "extra" } }), {});
 
   return { ...defaultHeaders, ...extraHeadersObj };
 }


### PR DESCRIPTION
```
curl 'https://api.staging.signadot.com/api/v2/orgs/signadot/sandboxes/test-baseline' \
  -H 'custom-routing-key: p9p72l1gfws8w' \
  -H 'tracestate: sd-routing-key=p9p72l1gfws8w,sd-sandbox=p9p72l1gfws8w' \
  -H 'x-routing-key: p9p72l1gfws8w'
```