### PR TITLE
Update version to v1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Signadot",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Signadot",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Just changes the package.json version to be consistent before we tag & build. The version now is 1.2.0. 
The manifest is already updated to 1.2.0 here: https://github.com/signadot/browser-extension/blob/2720e15e22313f80c5502fec84ad76033f4d32d3/public/manifest.json#L5