### PR TITLE
fix icon not indicating right state

### DIFF
--- a/src/contexts/StorageContext/StorageContext.tsx
+++ b/src/contexts/StorageContext/StorageContext.tsx
@@ -37,9 +37,21 @@ const getHeaders = (
 
 const updateIcon = (shouldInject: boolean) => {
   if (shouldInject) {
-    chrome.action.setIcon({ path: "images/icons/icon16_active.png" });
+    chrome.action.setIcon({
+      path: {
+        "16": "images/icons/icon16_active.png",
+        "48": "images/icons/icon48_active.png",
+        "128": "images/icons/icon128_active.png"
+      }
+    });
   } else {
-    chrome.action.setIcon({ path: "images/icons/icon16_inactive.png" });
+    chrome.action.setIcon({
+      path: {
+        "16": "images/icons/icon16_inactive.png",
+        "48": "images/icons/icon48_inactive.png",
+        "128": "images/icons/icon128_inactive.png"
+      }
+    });
   }
 };
 

--- a/src/contexts/StorageContext/utils.ts
+++ b/src/contexts/StorageContext/utils.ts
@@ -25,7 +25,7 @@ export const shouldInjectHeader = (
   headers: Header[],
   enabled: boolean,
 ): boolean => {
-  return isAuthenticated && typeof routingKey === "string" && headers.length > 0 && enabled;
+  return enabled && isAuthenticated && typeof routingKey === "string" && headers.length > 0;
 };
 
 export const parseSignadotConfig = (settings: Settings) => {


### PR DESCRIPTION
Fixes #62

The issue was that on the refactor of the state, i forgot to move the sideeffect hook that updates the icon

[Original](https://github.com/signadot/browser-extension/pull/31/files#diff-8ef192cd00fa1dd5b7665a692548be62c059bc44481104675e7f411ae9947a60R53-R68) snippet