### PR TITLE
Move the toggle from top bar to within card

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import styles from "./Layout.module.css";
-import { Switch, Tooltip } from "@blueprintjs/core";
 import { IoHomeSharp, IoSettingsSharp } from "react-icons/io5";
 import { useRouteView } from "../../contexts/RouteViewContext/RouteViewContext";
 import { DebugPanel } from "../DebugPanel/DebugPanel";
@@ -14,7 +13,7 @@ interface Props {
 
 const Layout: React.FC<Props> = ({ children }) => {
   const { currentView, goToView } = useRouteView();
-  const { isStoreLoaded, settings, setSettings, isAuthenticated } = useStorage();
+  const { isStoreLoaded, isAuthenticated } = useStorage();
   const { authState } = useAuth();
 
   const handleHomeChange = () => {
@@ -39,14 +38,6 @@ const Layout: React.FC<Props> = ({ children }) => {
             )}
           </div>
           <div className={styles.topRight}>
-            <Tooltip content={`Header injection ${settings.enabled ? "Enabled" : "Disabled"}`}>
-              <Switch
-                alignIndicator={"right"}
-                onChange={(e) => setSettings({ ...settings, enabled: e.target.checked })}
-                checked={settings.enabled}
-                large={true}
-              />
-            </Tooltip>
             <button onClick={() => goToView((prevView) => (prevView === "settings" ? handleHomeChange() : "settings"))}>
               {currentView === "settings" ? 
                 <IoHomeSharp size={20} /> : 

--- a/src/components/PinnedRouteGroup/PinnedRouteGroup.module.css
+++ b/src/components/PinnedRouteGroup/PinnedRouteGroup.module.css
@@ -15,6 +15,9 @@
 .title {
   font-weight: 600;
   font-size: 1.1rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .link {

--- a/src/components/PinnedRouteGroup/PinnedRouteGroup.tsx
+++ b/src/components/PinnedRouteGroup/PinnedRouteGroup.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { RoutingEntity, RoutingEntityType } from "../ListRouteEntries/types";
 import styles from "./PinnedRouteGroup.module.css";
-import { Button, Icon, Tag } from "@blueprintjs/core";
+import { Button, Icon, Tag, Switch, Tooltip } from "@blueprintjs/core";
 import { useStorage } from "../../contexts/StorageContext/StorageContext";
 import { getGroupedHeadersByKind } from "../../contexts/StorageContext/utils";
 
@@ -26,7 +26,7 @@ interface Props {
 
 const PinnedRouteGroup: React.FC<Props> = ({ routingEntity, onRemove }) => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const { headers, settings, setCurrentRoutingKey } = useStorage();
+  const { headers, settings, setSettings, setCurrentRoutingKey } = useStorage();
 
   let entityDashboardURL: string | undefined;
   if (settings.signadotUrls.dashboardUrl) {
@@ -51,9 +51,17 @@ const PinnedRouteGroup: React.FC<Props> = ({ routingEntity, onRemove }) => {
           ) : (
             routingEntity.name
           )}
+          <Tag minimal>{routingEntity.type}</Tag>
         </div>
         <div className={styles.headerActions}>
-          <Tag minimal>{routingEntity.type}</Tag>
+          <Tooltip content={`Header injection ${settings.enabled ? "Enabled" : "Disabled"}`}>
+            <Switch
+              alignIndicator={"right"}
+              onChange={(e) => setSettings({ ...settings, enabled: e.target.checked })}
+              checked={settings.enabled}
+              className="bp3-intent-success"
+            />
+          </Tooltip>
           <Button
             minimal
             small


### PR DESCRIPTION
Fixes https://github.com/signadot/browser-extension/issues/62
Moves the icon down into the card itself - this removes the cognitive load of dealing with a separate button.