### PR TITLE
Update version to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Signadot",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Signadot",
   "main": "index.js",
   "scripts": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Signadot",
   "description": "Browser Extension to enable preview functionality when using Signadot Sandboxes & Route Groups through the injection of headers",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "icons": {
     "16": "images/icons/icon16_active.png",
     "48": "images/icons/icon48_active.png",


### PR DESCRIPTION
Going with 2.0.0 because there's a big visual as well as below the hood overhaul here. Note that we're primarily using the major and minor versions, we don't use the patch version (so far).