### PR TITLE
Enable sliding window for routing entity list

### DIFF
--- a/src/components/ListRoutingEntities/ListRoutingEntities.tsx
+++ b/src/components/ListRoutingEntities/ListRoutingEntities.tsx
@@ -146,8 +146,8 @@ const ListRoutingEntities: React.FC<Props> = ({ routingEntities, setUserSelected
     return filterFunction(query, routingEntity);
   };
 
-  const listRenderer = ({ items, itemsParentRef, renderItem, query }: ItemListRendererProps<RoutingEntity>) => {
-    const filteredItems = items.filter((item) => filterFunction(query, item)).slice(0, SELECT_LIST_ITEM_COUNT);
+  const listRenderer = ({ items, itemsParentRef, renderItem, query, activeItem }: ItemListRendererProps<RoutingEntity>) => {
+    const filteredItems = items.filter((item) => filterFunction(query, item));
 
     if (filteredItems.length === 0) {
       return (
@@ -157,9 +157,20 @@ const ListRoutingEntities: React.FC<Props> = ({ routingEntities, setUserSelected
       );
     }
 
+    let startIndex = 0;
+    if (activeItem && "routingKey" in activeItem) {
+      const activeIndex = filteredItems.findIndex((item) => item.routingKey === activeItem.routingKey);
+      if (activeIndex >= 0) {
+        startIndex = Math.max(0, activeIndex - SELECT_LIST_ITEM_COUNT + 1);
+        startIndex = Math.min(startIndex, Math.max(0, filteredItems.length - SELECT_LIST_ITEM_COUNT));
+      }
+    }
+
+    const windowedItems = filteredItems.slice(startIndex, startIndex + SELECT_LIST_ITEM_COUNT);
+
     return (
       <Menu ulRef={itemsParentRef} className={styles.menu}>
-        {filteredItems.map(renderItem)}
+        {windowedItems.map((item, index) => renderItem(item, startIndex + index))}
       </Menu>
     );
   };

--- a/src/components/ListRoutingEntities/ListRoutingEntities.tsx
+++ b/src/components/ListRoutingEntities/ListRoutingEntities.tsx
@@ -18,6 +18,7 @@ interface Props {
 
 const ListRoutingEntities: React.FC<Props> = ({ routingEntities, setUserSelectedRoutingEntity, orgName }) => {
   const { settings, setHeaders, currentRoutingKey } = useStorage();
+  const windowStartIndexRef = React.useRef(0);
 
   const {
     data: clusters,
@@ -157,20 +158,27 @@ const ListRoutingEntities: React.FC<Props> = ({ routingEntities, setUserSelected
       );
     }
 
-    let startIndex = 0;
+    let windowStartIndex = windowStartIndexRef.current;
     if (activeItem && "routingKey" in activeItem) {
       const activeIndex = filteredItems.findIndex((item) => item.routingKey === activeItem.routingKey);
       if (activeIndex >= 0) {
-        startIndex = Math.max(0, activeIndex - SELECT_LIST_ITEM_COUNT + 1);
-        startIndex = Math.min(startIndex, Math.max(0, filteredItems.length - SELECT_LIST_ITEM_COUNT));
+        if (activeIndex >= windowStartIndex + SELECT_LIST_ITEM_COUNT) {
+          windowStartIndex = activeIndex - SELECT_LIST_ITEM_COUNT + 1;
+        }
+        else if (activeIndex < windowStartIndex) {
+          windowStartIndex = activeIndex;
+        }
       }
     }
 
-    const windowedItems = filteredItems.slice(startIndex, startIndex + SELECT_LIST_ITEM_COUNT);
+    windowStartIndex = Math.max(0, Math.min(windowStartIndex, Math.max(0, filteredItems.length - SELECT_LIST_ITEM_COUNT)));
+    windowStartIndexRef.current = windowStartIndex;
+
+    const windowedItems = filteredItems.slice(windowStartIndex, windowStartIndex + SELECT_LIST_ITEM_COUNT);
 
     return (
       <Menu ulRef={itemsParentRef} className={styles.menu}>
-        {windowedItems.map((item, index) => renderItem(item, startIndex + index))}
+        {windowedItems.map((item, index) => renderItem(item, windowStartIndex + index))}
       </Menu>
     );
   };


### PR DESCRIPTION
# Description
We're using an internal logic to construct the names of sandboxes and route groups. With a lot of sandboxes, this makes the search hard to navigate as the selection marker moves outside of the displayed range of items.

The reason is that the select-dropdown is currently slicing the filtered results to a fixed count starting from index 0, which meant items further down the list are hidden when navigating with arrow keys. 

This change keeps the active/highlighted item visible by sliding the render window based on the current selection. The list still caps at `SELECT_LIST_ITEM_COUNT` items but now follows the keyboard selection.

# How to reproduce
Open the extension and use the arrow keys to navigate downwards. The current behavior let's the selection marker move outside of the displayed range. With the change, displayed items are windowed according to the position of the selection marker.

# Demonstration
![recording2](https://github.com/user-attachments/assets/c8ec349e-ba49-490c-8e82-b27d7220d040)

# Testing
Tested locally.