### PR TITLE
Pin GitHub Actions in browser extension

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Update the browser-extension build workflow actions from mutable major tags to full commit SHAs with trailing version comments.
- Move stale `actions/checkout@v2` and `actions/setup-node@v1` refs to current majors (`v6` and `v5`).
- Add Dependabot configuration for the `github-actions` ecosystem.

## Validation
- Parsed `.github/workflows/build.yml` and `.github/dependabot.yml` as YAML.
- Verified every workflow `uses:` ref is a 40-character SHA with a trailing version comment.
- Ran temporary `actionlint` against `.github/workflows/build.yml`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-921](https://linear.app/signadot/issue/ENG-921/pin-github-actions-to-shas-across-signadot-repos)

<div><a href="https://cursor.com/agents/bc-15ce265b-a95b-4c2c-bddd-08dc22f1324c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15ce265b-a95b-4c2c-bddd-08dc22f1324c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

